### PR TITLE
Make solution parsing more robust.

### DIFF
--- a/src/multiple_choice/template.py
+++ b/src/multiple_choice/template.py
@@ -108,7 +108,7 @@ card_front = """\
 
     function onShuffle() {
         var solutions = document.getElementById("Q_solutions").innerHTML;
-        solutions = solutions.split(" ");
+        solutions = solutions.replace(/(<([^>]+)>)/gi, "").split(" ");
         for (i = 0; i < solutions.length; i++) {
             solutions[i] = Number(solutions[i]);
         }


### PR DESCRIPTION
Ensure solution text is free of html mark ups. 

### Why is it necessary
If you create Anki cards via other than its native application, e.g. Emacs, then you may end up with some html mark ups in each field unintentionally, such as `<p>...</p>` due to its exporting system. So, to suppress this kind of unfortunates, I propose this quick amendment.