### PR TITLE
Fix updateTemplate with new variable names

### DIFF
--- a/src/multiple_choice/template.py
+++ b/src/multiple_choice/template.py
@@ -511,13 +511,13 @@ def addModel(col):
 
 def updateTemplate(col):
     """Update add-on card templates"""
-    print("Updating %s card template".format(kprim_model))
-    model = col.models.byName(kprim_model)
+    print(f'Updating {aio_model} card template')
+    model = col.models.byName(aio_model)
     template = model['tmpls'][0]
     template['qfmt'] = card_front
     template['afmt'] = card_back
     model['css'] = card_css
-    col.models.save()
+    col.models.save(model)
     return model
 
 def initializeModel():


### PR DESCRIPTION
This is not yet complete. Perhaps someone has feedback if we should include a `config.py` to allow for the addon initialization to recognize if the card templates should be replaced or not.

A "dirty" way would be to replace the model every time by just calling `updateTemplate(mw.col)` in the initialization when the model is already established.

Intends to fix #41 