### PR TITLE
Fixed answer color coding

### DIFF
--- a/src/multiple_choice/template.py
+++ b/src/multiple_choice/template.py
@@ -332,15 +332,13 @@ card_back = """\
                     qrows[i].getElementsByTagName("td")[0].getElementsByTagName("input")[0].checked = (answers[i] == 1) ? true : false;
                 }
                 //Colorize the qtable.
-                if (colorizeqtable) {
-                    if (solutions[i] && answers[i] === "1") {
-                        qrows[(type != 0) ? i : i + 1].setAttribute("class", "correct");
-                    } else if (!solutions[i] && answers[i] === "0") {
-                        if (colorizefalsefalse) { qrows[(type != 0) ? i : i + 1].setAttribute("class", "correct"); }
-                    } else {
-                        qrows[(type != 0) ? i : i + 1].setAttribute("class", "wrong");
-                    }
-                }
+                if (solutions[i] && answers[i] === "1") {
+			qrows[(type != 0) ? i : i + 1].setAttribute("class", "correct");
+		} else if (solutions[i] && answers[i] === "0") {
+			qrows[(type != 0) ? i : i + 1].setAttribute("class", "correct");
+		} else if (!solutions[i] && answers[i] === "1") {
+			qrows[(type != 0) ? i : i + 1].setAttribute("class", "wrong");
+		}
             }
 
             var arows = document.getElementById("atable").getElementsByTagName("tbody")[0].getElementsByTagName("tr");


### PR DESCRIPTION
I saw a lot of people complaining about a color coding issue when they show the answers as it appears to be confusing which is the right answer and which is wrong. I have posted a comment on the plugin page on the official ANKI forum about how to modify the card back template code to show the convenient color-coding used by most Q banks and a lot of people contacted me saying that it worked best for them, so decided to make a pull request here, so changes are applied to the plugin itself.

I have modified the card back template to display green only if the choice is correct (whether I have chosen it or not) and displays red only if the choice is wrong and I have chosen it.