### PR TITLE
Improve multiline answer alignment with input checkboxes

### DIFF
--- a/src/multiple_choice/card/css.css
+++ b/src/multiple_choice/card/css.css
@@ -22,7 +22,7 @@ table {
 
 label {
   display: inline-block;
-  vertical-align:middle;
+  vertical-align: middle;
   margin-left: 0.4em;
 }
 

--- a/src/multiple_choice/card/css.css
+++ b/src/multiple_choice/card/css.css
@@ -21,6 +21,8 @@ table {
 }
 
 label {
+  display: inline-block;
+  vertical-align:middle;
   margin-left: 0.4em;
 }
 

--- a/src/multiple_choice/config.py
+++ b/src/multiple_choice/config.py
@@ -51,8 +51,8 @@ from .packaging import version
 
 # default configurations
 # TODO: update version number before release
-default_conf_local = {'version': "2.7.1"}
-default_conf_syncd = {'version': "2.7.1"}
+default_conf_local = {'version': "2.7.2"}
+default_conf_syncd = {'version': "2.7.2"}
 
 
 def getSyncedConfig():


### PR DESCRIPTION
I changed the label css-styling for better alignment of multiline answer text with the input checkboxes.

I'm a css-newbie, so maybe there is a better or cleaner solution. Feel free to commit.

current alignment:
![default](https://user-images.githubusercontent.com/92311392/208008590-0563b3d5-d7ac-46d3-8747-75a01a3be661.PNG)

improved alignment - QType kprim:
![QType_0](https://user-images.githubusercontent.com/92311392/208008594-6000b89d-d6c7-48fe-b8d2-04bec87a695a.PNG)

improved alignment - QType sc:
![QType_2](https://user-images.githubusercontent.com/92311392/208008586-2bf8f448-2a22-472e-be3d-39a21123ff41.PNG)

improved alignment - QType mc:
![QType_1](https://user-images.githubusercontent.com/92311392/208008596-c891798c-807a-4cfa-af58-963ccdd87458.PNG)
