### PR TITLE
Improve keeping question fields in sync with template

### DIFF
--- a/src/multiple_choice/config.py
+++ b/src/multiple_choice/config.py
@@ -52,8 +52,8 @@ from .packaging import version
 
 # default configurations
 # TODO: update version number before release
-default_conf_local = {"version": "2.10.1"}
-default_conf_syncd = {"version": "2.10.1"}
+default_conf_local = {"version": "2.10.2"}
+default_conf_syncd = {"version": "2.10.2"}
 
 
 def getSyncedConfig():

--- a/src/multiple_choice/tests/github-issue-113-front.html
+++ b/src/multiple_choice/tests/github-issue-113-front.html
@@ -1,0 +1,260 @@
+<script>
+    // Loading Persistence
+    // https://github.com/SimonLammer/anki-persistence
+    // v0.5.2 - https://github.com/SimonLammer/anki-persistence/blob/62463a7f63e79ce12f7a622a8ca0beb4c1c5d556/script.js
+    if (void 0 === window.Persistence) { var _persistenceKey = "github.com/SimonLammer/anki-persistence/", _defaultKey = "_default"; if (window.Persistence_sessionStorage = function () { var e = !1; try { "object" == typeof window.sessionStorage && (e = !0, this.clear = function () { for (var e = 0; e < sessionStorage.length; e++) { var t = sessionStorage.key(e); 0 == t.indexOf(_persistenceKey) && (sessionStorage.removeItem(t), e--) } }, this.setItem = function (e, t) { void 0 == t && (t = e, e = _defaultKey), sessionStorage.setItem(_persistenceKey + e, JSON.stringify(t)) }, this.getItem = function (e) { return void 0 == e && (e = _defaultKey), JSON.parse(sessionStorage.getItem(_persistenceKey + e)) }, this.removeItem = function (e) { void 0 == e && (e = _defaultKey), sessionStorage.removeItem(_persistenceKey + e) }) } catch (e) { } this.isAvailable = function () { return e } }, window.Persistence_windowKey = function (e) { var t = window[e], i = !1; "object" == typeof t && (i = !0, this.clear = function () { t[_persistenceKey] = {} }, this.setItem = function (e, i) { void 0 == i && (i = e, e = _defaultKey), t[_persistenceKey][e] = i }, this.getItem = function (e) { return void 0 == e && (e = _defaultKey), t[_persistenceKey][e] || null }, this.removeItem = function (e) { void 0 == e && (e = _defaultKey), delete t[_persistenceKey][e] }, void 0 == t[_persistenceKey] && this.clear()), this.isAvailable = function () { return i } }, window.Persistence = new Persistence_sessionStorage, Persistence.isAvailable() || (window.Persistence = new Persistence_windowKey("py")), !Persistence.isAvailable()) { var titleStartIndex = window.location.toString().indexOf("title"), titleContentIndex = window.location.toString().indexOf("main", titleStartIndex); titleStartIndex > 0 && titleContentIndex > 0 && titleContentIndex - titleStartIndex < 10 && (window.Persistence = new Persistence_windowKey("qt")) } }
+</script>
+
+{{#Image}}<p>{{Image}}</p>{{/Image}}
+
+<h3 id="myH1"></h3>
+{{#Question}}<p>{{Question}}</p>{{/Question}}
+
+<div class="tappable">
+    <table style="border: 1px solid black" id="qtable"></table>
+</div>
+
+<div class="hidden" id="Q_solutions">{{Answers}}</div>
+<div class="hidden" id="Card_Type">{{QType (0=kprim,1=mc,2=sc)}}</div>
+
+<div class="hidden" id="Q_1">{{Q_1}}</div>
+<div class="hidden" id="Q_2">{{Q_2}}</div>
+<div class="hidden" id="Q_3">{{Q_3}}</div>
+<div class="hidden" id="Q_4"></div>
+<div class="hidden" id="Q_5"></div>
+
+<script>
+    // Generate the table depending on the type.
+    function generateTable() {
+        var type = document.getElementById("Card_Type").innerHTML;
+        var table = document.createElement("table");
+        var tbody = document.createElement("tbody");
+        for (var i = 0; true; i++) {
+            if (type == 0 && i == 0) {
+                tbody.innerHTML = tbody.innerHTML + '<tr><th>yes</th><th>no</th><th></th></tr>';
+            }
+            if (document.getElementById('Q_' + (i + 1)) != undefined) {
+                if (document.getElementById('Q_' + (i + 1)).innerHTML != '') {
+                    var html = [];
+
+                    let answerText = document.getElementById('Q_' + (i + 1)).innerHTML;
+                    let labelTag = (type == 0) ? '' :
+                        '<label for="inputQuestion' + (i + 1) + '">' + answerText + '</label>';
+                    let textAlign = (type == 0) ? 'center' : 'left';
+
+                    html.push('<tr>');
+                    var maxColumns = ((type == 0) ? 2 : 1);
+                    for (var j = 0; j < maxColumns; j++) {
+                        let inputTag = '<input id="inputQuestion' + (i + 1) +
+                            '" name="ans_' + ((type != 2) ? (i + 1) : 'A') +
+                            '" type="' + ((type == 1) ? 'checkbox' : 'radio') +
+                            // TODO: I don't see how these values are used, please add a comment
+                            '" value="' + ((j == 0) ? 1 : 0) + '">';
+                        html.push(
+                            '<td onInput="onCheck()" style="text-align: ' + textAlign + '">' + inputTag +
+                            labelTag +
+                            '</td>');
+                    }
+                    if (type == 0) {
+                        html.push('<td>' + answerText + '</td>');
+                    }
+                    html.push('</tr>');
+                    tbody.innerHTML = tbody.innerHTML + html.join("");
+                }
+            } else {
+                break;
+            }
+        }
+
+        table.appendChild(tbody);
+        document.getElementById('qtable').innerHTML = table.innerHTML;
+        onShuffle();
+    }
+
+    function shuffle(array) {
+        var currentIndex = array.length, temporaryValue, randomIndex;
+
+        // While there remain elements to shuffle...
+        while (0 !== currentIndex) {
+
+            // Pick a remaining element...
+            randomIndex = Math.floor(Math.random() * currentIndex);
+            currentIndex -= 1;
+
+            // And swap it with the current element.
+            temporaryValue = array[currentIndex];
+            array[currentIndex] = array[randomIndex];
+            array[randomIndex] = temporaryValue;
+        }
+
+        return array;
+    }
+
+    function onShuffle() {
+        var solutions = document.getElementById("Q_solutions").innerHTML;
+        solutions = solutions.replace(/(<([^>]+)>)/gi, "").split(" ");
+        for (var i = 0; i < solutions.length; i++) {
+            solutions[i] = Number(solutions[i]);
+        }
+
+        var output = document.getElementById("output");
+
+        var qrows = document.getElementById("qtable").getElementsByTagName("tr");
+
+        var qanda = new Array();
+
+        var type = document.getElementById("Card_Type").innerHTML;
+
+        for (i = 0; i < ((type == 0) ? qrows.length - 1 : qrows.length); i++) {
+            qanda[i] = new Object();
+            qanda[i].question = qrows[(type == 0) ? i + 1 : i].getElementsByTagName("td")[(type == 0) ? 2 : 0].innerHTML;
+            qanda[i].answer = solutions[i];
+        }
+
+        qanda = shuffle(qanda);
+
+        var mc_solutions = new String();
+
+        for (i = 0; i < ((type == 0) ? qrows.length - 1 : qrows.length); i++) {
+            qrows[(type == 0) ? i + 1 : i].getElementsByTagName("td")[(type == 0) ? 2 : 0].innerHTML = qanda[i].question;
+            solutions[i] = qanda[i].answer;
+            mc_solutions += qanda[i].answer + " ";
+        }
+        mc_solutions = mc_solutions.substring(0, mc_solutions.lastIndexOf(" "));
+        document.getElementById("Q_solutions").innerHTML = mc_solutions;
+
+        document.getElementById("qtable").HTML = qrows;
+        onCheck();
+    }
+
+    /**
+     * Returns true if the option box/circle is checked.
+     *
+     * In case of kprim the second box is used as reference.
+     *
+     * @param   {HTMLTableRowElement}    optionRow    Row containing option boxes/circles.
+     * @param   {number}    index   Index of the option in question.
+     */
+    function isOptionChecked(optionRow, index) {
+        return optionRow.getElementsByTagName("td")[index].getElementsByTagName("input")[0].checked
+    }
+
+    function getUserAnswers() {
+        let type = document.getElementById("Card_Type").innerHTML;
+        let qrows = document.getElementById("qtable").getElementsByTagName('tbody')[0].getElementsByTagName("tr");
+        let userAnswers = [];
+        for (let i = 0; i < qrows.length; i++) {
+            if (type == 0 && i == 0) {
+                i++; // to skip the first row containing no checkboxes when type is 'kprim'
+            }
+            if (type == 0) {
+                if (isOptionChecked(qrows[i], 0)) {
+                    userAnswers.push(1);
+                } else if (isOptionChecked(qrows[i], 1)) {
+                    userAnswers.push(0);
+                } else {
+                    userAnswers.push(2);
+                }
+            } else {
+                if (isOptionChecked(qrows[i], 0)) {
+                    userAnswers.push(1);
+                } else {
+                    userAnswers.push(0);
+                }
+            }
+        }
+        return userAnswers
+    }
+
+    function getCorrectAnswers() {
+        let solutions = document.getElementById("Q_solutions").innerHTML.split(" ").map(string => Number(string));
+
+        return solutions;
+    }
+
+    /**
+     * On checking an option this collects and stores answers in between front/back of the card.
+     *
+     * In case of kprim only the first box is looked at, if it isn't checked the second box has to be.
+     * By default a '1' in the answers stands for 'yes' which is the first option from the left.
+     */
+    function onCheck() {
+        // Send question table and encoded answers to Persistence along with the provided solutions
+        if (Persistence.isAvailable()) {
+            Persistence.clear();
+            Persistence.setItem('user_answers', getUserAnswers());
+            Persistence.setItem('Q_solutions', getCorrectAnswers());
+            Persistence.setItem('qtable', document.getElementById("qtable").innerHTML);
+        }
+    }
+
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function tickCheckboxOnNumberKeyDown(event) {
+        const keyName = event.key;
+
+        let tableBody = document.getElementById("qtable").getElementsByTagName('tbody')[0];
+        var tableRows = tableBody.getElementsByTagName("tr");
+
+        if (0 < +keyName && +keyName < 10) {
+            let tableData = tableRows[+keyName - 1].getElementsByTagName("td")[0];
+            let tableRow = tableData.getElementsByTagName("input")[0];
+            tableRow.checked = !tableRow.checked;
+            onCheck();
+        }
+    }
+
+    // addCheckboxTickingShortcuts is an easy approach on using only the keyboard to toggle checkboxes in mc/sc.
+    //
+    // Naturally the number keys are an intuitive choice here. Unfortunately anki does capture those.
+    // So the workaround is to hold the (left) 'Alt' key and then type the corresponding number to toggle the row.
+    function addCheckboxTickingShortcuts() {
+        document.addEventListener('keydown', tickCheckboxOnNumberKeyDown, false);
+    }
+
+    function isMobile() {
+        if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function run() {
+        let DEFAULT_CARD_TYPE = 1; // for previewing the cards in "Manage Note Type..."
+
+        if (isNaN(document.getElementById("Card_Type").innerHTML)) {
+            document.getElementById("Card_Type").innerHTML = DEFAULT_CARD_TYPE;
+        }
+
+        if (document.getElementById("Card_Type").innerHTML != 0 && !isMobile()) {
+            addCheckboxTickingShortcuts();
+        }
+
+        setTimeout(generateTable(), 1);
+    }
+
+    async function waitForReadyStateAndRun() {
+        for (let i = 0; i < 100; i++) {
+            if (document.readyState === "complete") {
+                run();
+                break;
+            }
+            console.log("Document not yet fully loaded (readyState: " + document.readyState + "). Retry in 0.1s.");
+            await sleep(100);
+        }
+    }
+
+    /*
+    The following block is inspired by Glutanimate's Cloze Overlapper card template.
+    The Cloze Overlapper card template is licensed under the CC BY-SA 4.0
+    license (https://creativecommons.org/licenses/by-sa/4.0/).
+    */
+    if (document.readyState === "complete") {
+        run();
+    } else {
+        waitForReadyStateAndRun();
+    }
+</script>

--- a/src/multiple_choice/tests/test_template.py
+++ b/src/multiple_choice/tests/test_template.py
@@ -348,6 +348,43 @@ class TestTemplateMethods(unittest.TestCase):
 
         self.assertEqual(model["tmpls"][0]["qfmt"], MODEL_QFMT_Q1_TO_Q7)
 
+    @patch("multiple_choice.template.mw", autospec=True)
+    @patch("multiple_choice.template.get_model_front_template_text")
+    def test_given_certain_fields_when_adjust_number_of_question_fields_is_called_then_no_changes_and_no_errors(
+        self, get_model_front_template_text: MagicMock, mw
+    ):
+        self.maxDiff = None
+
+        model_manager = MagicMock()
+        model_manager.field_names.return_value = [
+            "Note ID",
+            "Image",
+            "Question",
+            "QType (0=kprim,1=mc,2=sc)",
+            "Q_1",
+            "Q_2",
+            "Q_3",
+            "Answers",
+            "Sources",
+        ]
+
+        front_template = ""
+        with open(
+            "src/multiple_choice/tests/github-issue-113-front.html", encoding="utf-8"
+        ) as f:
+            front_template = f.read()
+
+        get_model_front_template_text.return_value = front_template
+        model = get_default_model(front_template)
+
+        mw.col.models = model_manager
+        mw.col.models.by_name.return_value = model
+        mw.col.get_config.return_value = {"version": "9.9.9"}
+
+        adjust_number_of_question_fields(model)
+
+        self.assertEqual(model["tmpls"][0]["qfmt"], front_template)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/multiple_choice/tests/test_template.py
+++ b/src/multiple_choice/tests/test_template.py
@@ -23,7 +23,6 @@ from multiple_choice.template import (
     add_added_field_to_template,
     adjust_number_of_question_fields,
     aio_model_name,
-    get_default_front_template_text,
     get_front_template_with_added_field,
     get_front_template_with_removed_field,
     manage_multiple_choice_note_type,

--- a/src/multiple_choice/tests/test_template.py
+++ b/src/multiple_choice/tests/test_template.py
@@ -23,8 +23,7 @@ from multiple_choice.template import (
     add_added_field_to_template,
     adjust_number_of_question_fields,
     aio_model_name,
-    get_addon_path,
-    get_front_template_text,
+    get_default_front_template_text,
     get_front_template_with_added_field,
     get_front_template_with_removed_field,
     manage_multiple_choice_note_type,
@@ -108,9 +107,19 @@ MODEL_QFMT_Q1_TO_Q7 = """# Start of the template front
 # Rest of the template front with some fake matches: Q_4 Q_5 <div>
 """
 
+MODEL_QFMT_PARTIAL_Q1_TO_Q3 = """# Start of the template front
+<div class="hidden" id="Q_1">{{Q_1}}</div>
+<div class="hidden" id="Q_2">{{Q_2}}</div>
+<div class="hidden" id="Q_3">{{Q_3}}</div>
+<div class="hidden" id="Q_4"></div>
+<div class="hidden" id="Q_5"></div>
 
-def get_default_model() -> dict[str, Any]:
-    return {"name": aio_model_name, "tmpls": [{"qfmt": MODEL_QFMT}]}
+# Rest of the template front with some fake matches: Q_4 Q_5 <div>
+"""
+
+
+def get_default_model(qfmt=MODEL_QFMT) -> dict[str, Any]:
+    return {"name": aio_model_name, "tmpls": [{"qfmt": qfmt}]}
 
 
 class TestTemplateMethods(unittest.TestCase):
@@ -149,23 +158,23 @@ class TestTemplateMethods(unittest.TestCase):
 
     @patch("multiple_choice.template.update_model")
     @patch("multiple_choice.template.get_front_template_with_removed_field")
-    @patch("multiple_choice.template.get_front_template_text")
+    @patch("multiple_choice.template.get_model_front_template_text")
     @patch("multiple_choice.template.fields.FieldDialog")
     def test_when_remove_deleted_field_from_template_is_called_then_calls_correct_methods(
         self,
         field_dialog,
-        get_front_template_text: MagicMock,
+        get_model_front_template_text: MagicMock,
         get_front_template_with_removed_field: MagicMock,
         update_model: MagicMock,
     ):
         field_dialog.model = get_default_model()
-        get_front_template_text.return_value = MODEL_QFMT
+        get_model_front_template_text.return_value = MODEL_QFMT
 
         field: dict[str, Any] = {"name": "Q_5"}
 
         remove_deleted_field_from_template(field_dialog, field)
 
-        get_front_template_text.assert_called_once()
+        get_model_front_template_text.assert_called_once()
         get_front_template_with_removed_field.assert_called_once_with(field, MODEL_QFMT)
         update_model.assert_called_once()
 
@@ -210,23 +219,23 @@ class TestTemplateMethods(unittest.TestCase):
 
     @patch("multiple_choice.template.update_model")
     @patch("multiple_choice.template.get_front_template_with_added_field")
-    @patch("multiple_choice.template.get_front_template_text")
+    @patch("multiple_choice.template.get_model_front_template_text")
     @patch("multiple_choice.template.fields.FieldDialog")
     def test_when_add_added_field_to_template_is_called_then_calls_correct_methods(
         self,
         field_dialog,
-        get_front_template_text: MagicMock,
+        get_model_front_template_text: MagicMock,
         get_front_template_with_added_field: MagicMock,
         update_model: MagicMock,
     ):
         field_dialog.model = get_default_model()
-        get_front_template_text.return_value = MODEL_QFMT
+        get_model_front_template_text.return_value = MODEL_QFMT
 
         field: dict[str, Any] = {"name": "Q_6"}
 
         add_added_field_to_template(field_dialog, field)
 
-        get_front_template_text.assert_called_once()
+        get_model_front_template_text.assert_called_once()
         get_front_template_with_added_field.assert_called_once_with(field, MODEL_QFMT)
         update_model.assert_called_once()
 
@@ -248,8 +257,9 @@ class TestTemplateMethods(unittest.TestCase):
         )
 
     @patch("multiple_choice.template.mw", autospec=True)
+    @patch("multiple_choice.template.get_default_front_template_text")
     def test_given_default_question_fields_when_adjust_number_of_question_fields_is_called_then_do_nothing(
-        self, mw
+        self, get_default_front_template_text: MagicMock, mw
     ):
         self.maxDiff = None
 
@@ -265,6 +275,8 @@ class TestTemplateMethods(unittest.TestCase):
             "Extra 1",
         ]
 
+        get_default_front_template_text.return_value = MODEL_QFMT
+
         model = get_default_model()
 
         mw.col.models = model_manager
@@ -276,8 +288,9 @@ class TestTemplateMethods(unittest.TestCase):
         self.assertEqual(model, get_default_model())
 
     @patch("multiple_choice.template.mw", autospec=True)
+    @patch("multiple_choice.template.get_default_front_template_text")
     def test_given_too_few_question_fields_when_adjust_number_of_question_fields_is_called_then_add_divs(
-        self, mw
+        self, get_default_front_template_text: MagicMock, mw
     ):
         self.maxDiff = None
 
@@ -291,6 +304,8 @@ class TestTemplateMethods(unittest.TestCase):
             "Extra 1",
         ]
 
+        get_default_front_template_text.return_value = MODEL_QFMT
+
         model = get_default_model()
 
         mw.col.models = model_manager
@@ -302,8 +317,9 @@ class TestTemplateMethods(unittest.TestCase):
         self.assertEqual(model["tmpls"][0]["qfmt"], MODEL_QFMT_Q1_TO_Q3)
 
     @patch("multiple_choice.template.mw", autospec=True)
-    def test_given_too_many_question_fields_when_adjust_number_of_question_fields_is_called_then_remove_divs(
-        self, mw
+    @patch("multiple_choice.template.get_default_front_template_text")
+    def test_given_too_many_question_fields_when_adjust_number_of_question_fields_is_called_then_add_divs(
+        self, get_default_front_template_text: MagicMock, mw
     ):
         self.maxDiff = None
 
@@ -320,6 +336,8 @@ class TestTemplateMethods(unittest.TestCase):
             "Q_7",
             "Extra 1",
         ]
+
+        get_default_front_template_text.return_value = MODEL_QFMT
 
         model = get_default_model()
 


### PR DESCRIPTION
#### Description

Before it was not clear if the template still used the not yet saved pristine default template or the potentially outdated/tainted user template. ~I couldn't reproduce the error #113 motivating this patch though.~ There has been an error when a default template field was removed. It needs to be readded when the default template is reinstalled (with the user defined number of questions).

Use caching to read templates only once.

- Tested with Anki Version ⁨2.1.65 (aa9a734f)⁩
- Resolves #113 
