### PR TITLE
Skip Flip Option (Resolves #136)

### DIFF
--- a/src/multiple_choice/card/front.html
+++ b/src/multiple_choice/card/front.html
@@ -22,14 +22,13 @@
 <div class="hidden" id="Q_5">{{Q_5}}</div>
 
 <script>
+    // Options are modified according to user's meta.json in the addon's folder
+    const OPTIONS = {
+        maxQuestionsToShow: 0,
+        skipFlip: false
+    };
     // Generate the table depending on the type.
     function generateTable() {
-
-        // Options are modified according to user's meta.json in the addon's folder
-        const OPTIONS = {
-            maxQuestionsToShow: 0
-        };
-
         var type = document.getElementById("Card_Type").innerHTML;
         var table = document.createElement("table");
         var tbody = document.createElement("tbody");
@@ -210,7 +209,25 @@
             Persistence.setItem('Q_solutions', getCorrectAnswers());
             Persistence.setItem('qtable', document.getElementById("qtable").innerHTML);
         }
+        const type = document.getElementById("Card_Type").innerHTML;
+        if (type == 2 && OPTIONS.skipFlip && getUserAnswers().filter(a => a == 1).length == 1) {
+            flipToBack();
+        }
     }
+
+    // flipToBack reference to https://github.com/git9527/anki-awesome-select
+    function flipToBack() {
+        if (typeof pycmd !== "undefined") {
+            pycmd("ans")
+        } else if (typeof study !== "undefined") {
+            study.drawAnswer()
+        } else if (typeof AnkiDroidJS !== "undefined") {
+            showAnswer()
+        } else if (window.anki && window.sendMessage2) {
+            window.sendMessage2("ankitap", "midCenter")
+        }
+    }
+
 
     function sleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));

--- a/src/multiple_choice/config.json
+++ b/src/multiple_choice/config.json
@@ -3,5 +3,6 @@
     "colorQuestionTable": false,
     "colorAnswerTable": true,
     "hideAnswerTable": false,
-    "maxQuestionsToShow": 0
+    "maxQuestionsToShow": 0,
+    "skipFlip": false
 }

--- a/src/multiple_choice/config.md
+++ b/src/multiple_choice/config.md
@@ -15,3 +15,6 @@
 - `maxQuestionsToShow` (`number`)
     - `0`: (default) Show all questions that are defined in the fields on the card
     - `n >= 1`: Show only `n` questions from the ones defined in the fields on the card
+- `skipFlip` (`bool`)
+    - `true`: Skip flipping the card after choosing an answer while using single choice questions.
+    - `false` (default): Flip the card after choosing an answer while using single choice questions.

--- a/src/multiple_choice/template.py
+++ b/src/multiple_choice/template.py
@@ -95,7 +95,8 @@ def getOptionsJavaScriptFromConfig(user_config, side: Template_side):
         "\n".join(
             [
                 "const OPTIONS = {",
-                f"    maxQuestionsToShow: {user_config['maxQuestionsToShow']}",
+                f"    maxQuestionsToShow: {user_config['maxQuestionsToShow']},",
+                f"    skipFlip: {'true' if user_config['skipFlip'] else 'false'}",
                 "};",
             ]
         )


### PR DESCRIPTION
#### Description

Adds the option to enable automatic flipping on answer selection when being in sc mode. (Resolves #136)

#### Checklist
- [x] I've read the [contribution guideline](https://github.com/zjosua/anki-mc/blob/master/docs/contributing.md)
- [x] I've tested my change with the following Anki version: 24.04.1 and 24.11
- [x] I've tested my change on the following operating system(s): Mac
- [x] If the change is related to an issue, a commit message or the above description references the issue
  - [x] If the change resolves an issue, a commit message or the above description links the issue with a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

It would be great if someone could test it on other platforms and versions.
